### PR TITLE
Auto-detect the newest container version

### DIFF
--- a/run_node.sh
+++ b/run_node.sh
@@ -30,7 +30,6 @@ Help()
 # The defaults
 NAME="aleph-node-$(xxd -l "16" -p /dev/urandom | tr -d " \n" ; echo)"
 BASE_PATH="/data"
-ALEPH_VERSION="r-5.2"
 DATE=$(date -d "yesterday" '+%Y-%m-%d')  # yesterday's date to make sure the snapshot is already uploaded (it happens once a day)
 DB_SNAPSHOT_FILE="db_backup_${DATE}.tar.gz"
 DB_SNAPSHOT_URL="https://db.test.azero.dev/${DATE}/${DB_SNAPSHOT_FILE}"
@@ -102,6 +101,11 @@ fi
 if [ -z "$ALEPH_IMAGE" ]
 then
     echo "Pulling docker image..."
+    if [ -z "$ALEPH_VERSION" ]
+    then
+        # find the newest version
+        ALEPH_VERSION=$(docker image ls --format  '{{ .Tag }}'  public.ecr.aws/p6e8q1z1/aleph-node | head -n 1)
+    fi
     ALEPH_IMAGE=public.ecr.aws/p6e8q1z1/aleph-node:${ALEPH_VERSION}
     docker pull ${ALEPH_IMAGE}
 fi


### PR DESCRIPTION
All this is needed because we don't maintain a `latest` tag in the docker registry. A bit fragile solution, as it relies on the `docker image ls` output to be sorted by image creation time (which it is, for now).