### PR TITLE
Policy for docker container: "restart unless stopped"

### DIFF
--- a/run_node.sh
+++ b/run_node.sh
@@ -67,7 +67,7 @@ while [[ $# -gt 0 ]]; do
             shift;;
         -* | --* )
             echo "Warning: unrecognized option: $1"
-            exit;; 
+            exit;;
         *)
             echo "Unrecognized command"
             Help
@@ -127,6 +127,6 @@ then
                -u $(id -u):$(id -g) \
                --mount type=bind,source=$(pwd),target=${BASE_PATH} \
                --name ${NAME} \
+               --restart unless-stopped \
                -d ${ALEPH_IMAGE}
 fi
-


### PR DESCRIPTION
Dear Cardinal team, hello!

For your kind consideration, a small suggestion from the community to make the aleph-node container persistent across reboots via the `--restart unless-stopped` flag.

there are other alternatives according to [docker documentation](https://docs.docker.com/config/containers/start-containers-automatically/) but the option unless-stopped seems the more desired behaviour for a node, feel free to amend to your preferences.

Many thanks!!! YOU ALL ROCK!!!

Best regards... 

Milos