### PR TITLE
A0-1361: set session keys check

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd aleph-node-runner
 Once inside the `aleph-node-runner` folder, run:
 
 ```bash
-./run_node.sh --name <your_nodes_name>
+./run_node.sh --name <your_nodes_name> --stash_account <validator_stash_account_id>
 ```
 
 It might take quite some time before you actually get the node running: the script will first download required files, including a database snapshot (sized ~100GB). You can alternatively skip this step by providing the `--skip` flag (see the 'Additional Options' section). The script will then run the node for you and you should start seeing some block-related output.
@@ -45,4 +45,5 @@ The script allows you to customize the run in several ways, as listed below.
 * `--image`: you can provide the name and tag of your own Aleph Node image in case you don't want to use one from the official image repository
 * `--archivist`: (as described above) run the node as an archivist instead of a validator
 * `--name`: (as described above) provide the name of the node. If you omit this option, one will be generated for you but it's not encouraged.
+* `--stash_account`: provide `AccountId` of the stash account linked to your validator node. If you run as validator, then this argument is mandatory.
 

--- a/run_node.sh
+++ b/run_node.sh
@@ -9,7 +9,7 @@ Help()
     echo
     echo "options:"
     echo "archivist         Run the node as an archivist (the default is to run as a validator)."
-    echo "stash_account     Stash account of your validator - mandatory if --archivist is not set."
+    echo "stash_account     Stash account of your validator: optional but recommended, if you're re-running the script."
     echo "n | name          Set the node's name."
     echo "mainnet           Join the mainnet (by default the script will join testnet)."
     echo "i | image         Specify the Docker image to use"
@@ -145,8 +145,17 @@ fi
 
 if [[ -z "${STASH_ACCOUNT}" ]]
 then
-    echo "Stash account not provided: skipping the session keys check."
-    exit 0
+    echo "Stash account not provided. This is ok if you're running the script for the first time but recommended for subsequent runs."
+    echo "Are you sure you want to skip the session keys check? [y]/n"
+    read -r CHECK
+    if [[ "${CHECK}" = 'n' ]]
+    then
+        echo "Skipping the session keys check."
+        exit 0
+    fi
+
+    echo "Please provide your stash account: "
+    read -r STASH_ACCOUNT
 fi
 
 ## Now we will attempt to check validator's session keys

--- a/run_node.sh
+++ b/run_node.sh
@@ -155,7 +155,7 @@ JQ_IMAGE='stedolan/jq:latest'
 docker pull "$CLIAIN_IMAGE"
 
 # Try to retrieve set session keys from chain's storage
-if ! SESSION_KEYS_JSON=$(docker run --network="host" "$CLIAIN_IMAGE" --node "localhost:$WS_PORT" \
+if ! SESSION_KEYS_JSON=$(docker run --network="host" "$CLIAIN_IMAGE" --node 127.0.0.1:"$WS_PORT" \
     next-session-keys --account-id "$STASH_ACCOUNT" 2> '/tmp/.alephzero_cliain.log');
 then
     # This should not happen even if the keys are not set
@@ -179,7 +179,7 @@ then
     # Perform an RPC call to the local node to check whether it has access to the keys
     HAS_KEYS_RESULT_JSON=$(curl -H "Content-Type: application/json" \
         -d '{"id":1, "jsonrpc":"2.0", "method": "author_hasSessionKeys",
-            "params":["'"$SESSION_KEYS_STRING"'"]}' http://127.0.0.1:9933 2> /dev/null)
+            "params":["'"$SESSION_KEYS_STRING"'"]}' http://127.0.0.1:"$RPC_PORT" 2> /dev/null)
 
     HAS_KEYS_RESULT=$(echo "$HAS_KEYS_RESULT_JSON" | docker run -i "$JQ_IMAGE" '.result')
 

--- a/run_node.sh
+++ b/run_node.sh
@@ -201,6 +201,10 @@ then
         docker stop "$NAME"
         exit 1
     fi
+else
+    echo ""
+    echo "Specified account do not have any session keys set."
+    echo "You should generate and set the keys to be able to validate."
 fi
 
 exit 0

--- a/run_node.sh
+++ b/run_node.sh
@@ -18,10 +18,10 @@ Help()
     echo "help              Print this help."
     echo
     echo "Example usage:"
-    echo "./run_node.sh --name my-aleph-node --mainnet"
+    echo "./run_node.sh --name my-aleph-node --mainnet --stash_account 5CeeD3MGHCvZecJkvfJVzYvYkoPtw9pTVvskutXAUtZtjcYa"
     echo
     echo "or, shorter:"
-    echo "./run_node.sh --n my-aleph-node --mainnet"
+    echo "./run_node.sh --n my-aleph-node --mainnet --stash_account 5CeeD3MGHCvZecJkvfJVzYvYkoPtw9pTVvskutXAUtZtjcYa"
     echo
 }
 

--- a/run_node.sh
+++ b/run_node.sh
@@ -79,7 +79,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-STASH_ACCOUNT=${STASH_ACCOUNT:?'Please specify your stash account_id.'}
+if [[ -z "$ARCHIVIST" ]]
+then
+    STASH_ACCOUNT=${STASH_ACCOUNT:?'Please specify your stash account_id.'}
+fi
+
 ALEPH_VERSION=$(cat env/version)
 
 mkdir -p ${DB_SNAPSHOT_PATH}

--- a/run_node.sh
+++ b/run_node.sh
@@ -146,16 +146,16 @@ fi
 if [[ -z "${STASH_ACCOUNT}" ]]
 then
     echo "Stash account not provided. This is ok if you're running the script for the first time but recommended for subsequent runs."
-    echo "Are you sure you want to skip the session keys check? [y]/n"
-    read -r CHECK
-    if [[ "${CHECK}" = 'n' ]]
+    read -p "Are you sure you want to skip the session keys check? [y/N]" -r -n 1
+    echo ""
+
+    if [[ "${REPLY}" =~ ^[Yy] ]]
     then
         echo "Skipping the session keys check."
         exit 0
     fi
 
-    echo "Please provide your stash account: "
-    read -r STASH_ACCOUNT
+    read -p "Please provide your stash account: " -r STASH_ACCOUNT
 fi
 
 ## Now we will attempt to check validator's session keys

--- a/run_node.sh
+++ b/run_node.sh
@@ -79,11 +79,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [[ -z "${ARCHIVIST}" ]]
-then
-    STASH_ACCOUNT=${STASH_ACCOUNT:?'Please specify your stash account_id.'}
-fi
-
 ALEPH_VERSION=$(cat env/version)
 
 mkdir -p ${DB_SNAPSHOT_PATH}
@@ -145,6 +140,12 @@ echo 'Performing session key checks...'
 if [[ -n "${ARCHIVIST}" ]]
 then
     echo 'Node run as archivist: no need to check session keys.'
+    exit 0
+fi
+
+if [[ -z "${STASH_ACCOUNT}" ]]
+then
+    echo "Stash account not provided: skipping the session keys check."
     exit 0
 fi
 


### PR DESCRIPTION
Adds a session key check to `run_node.sh`:
- When run as a validator it takes mandatory `--stash_account` argument
- Checks if session keys are set for this stash account - uses `cliain`
- If there are, then makes an RPC call to the node, checking if node has access to the keys.
- If not, it will stop the node and print an error.