### PR TITLE
A0-1377 Fix duplicate telemetry endpoint

### DIFF
--- a/env/validator
+++ b/env/validator
@@ -21,4 +21,5 @@ PORT_MAP="${PORT}:${PORT}"
 VALIDATOR_PORT_MAP="${VALIDATOR_PORT}:${VALIDATOR_PORT}"
 METRICS_PORT_MAP="127.0.0.1:${METRICS_PORT}:${METRICS_PORT}"
 TELEMETRY_ENABLED=true
-CUSTOM_ARGS="--telemetry-url \'wss://telemetry.polkadot.io/submit/ 1\'"
+TELEMETRY_URL="wss://telemetry.polkadot.io/submit/"
+TELEMETRY_VERBOSITY_LVL="1"


### PR DESCRIPTION
Since we specify `--telemetry-url` in `aleph-node` we should no longer pass it in `aleph-node-runner` - now we just need to pass config through variables. 