### PR TITLE
Add the keep_containers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The script allows you to customize the run in several ways, as listed below:
 * `--dns`: your public domain address (this or `--ip` is required)
 * `--data_dir`: specify the directory in which all of the chain data will be stored (defaults to `~/.alephzero`)
 * `--mainnet`: join the Aleph Mainnet instead of the default Testnet
+* `--keep_containers`: don't stop or remove existing `aleph-node` containers (by default the script does that to ensure minimal downtime) 
 * `--sync_from_genesis`: by providing this option, you're choosing not to download and use a DB snapshot, but rather perform a full sync
 * `--build_only`: the script will only download and setup everything but will not actually run the binary in case you don't want to join the network yet
 * `--archivist`: (as described above) run the node as an archivist instead of a validator


### PR DESCRIPTION
Some users are running a mainnet and testnet node on one machine. While this is not recommended, the node runner should either handle it gracefully (and print a warning) or not get in the way. This allows you to override the default behavior that removes all aleph-node containers and simply lets you handle it yourself.